### PR TITLE
removed dplyr NOTEs

### DIFF
--- a/R/kapow.R
+++ b/R/kapow.R
@@ -25,7 +25,10 @@ kapow <- function(cd = 7, ng = 25, n = 50, sc = 10, do.plot = TRUE) {
   
   Y <- generateSiberCommunity(n.groups = ng, n.obs = n, wishSigmaScale = sc)
   
-  Y <- Y %>% mutate(group = factor(group))
+  # dplyr version causes NOTE to be generated with
+  # "no visible binding for global variable ‘group’"
+  # Y <- Y %>% mutate(group = factor(group))
+  Y$group <- factor(Y$group)
   
   # myScale <- function(x){ (x - mean(x)) / sd(x)}
   # Y <- Y %>% group_by(group) %>% mutate(iso1 = myScale(iso1), 

--- a/R/siberKapow.R
+++ b/R/siberKapow.R
@@ -40,7 +40,6 @@ siberKapow <- function(dtf, isoNames = c("iso1", "iso2"),
                       n = 360 * 1,
                       p.interval = pEll,
                       ci.mean = FALSE,
-                      col = i,
                       lty = 3,
                       lwd = 2,
                       small.sample = TRUE,
@@ -60,7 +59,10 @@ siberKapow <- function(dtf, isoNames = c("iso1", "iso2"),
     do(calcBoundaries(.data))
   
   # split the dataset by the defined grouping parameter
-  ellCoords.list <- ellCoords %>% split(., .[,group])
+  # The piped version causes NOTEs
+  # "no visible binding for global variable ‘group’"
+  # ellCoords.list <- ellCoords %>% split(., .[,group])
+  ellCoords.list <- split(ellCoords, ellCoords$group)
   
   # Define a short custom function and then apply it over the list
   # using map()

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,6 @@
-Some checks highlighted in correspondance from Brian Ripley regarding new checks on vignettes that SIBER failed. I have rectified these in this release. SIBER was removed from CRAN with the note "Archived on 2019-01-23 as check issues were not corrected in time."
-
 ## Resubmission
-* A submission on 14-Feb-2019 was automatically rejected owing to a failed vignette re-build. I have rectified by adding `library(SIBER)` to this 'Points-Inside-Outside-Ellipse.Rmd'.
+* Thanks Uwe for responding to my last submission on 19-FEB-2019 clarifying the need to remove the "no visible binding for variable 'xyz'" arising from my use of piped syntax with dplyr. I have removed these two NOTEs. Not by adding global variables, but in both instances by using base syntax and directly naming the variable using dollar sign notation within the data.frame, e.g. `df$group`. Thanks for taking the time to resond in person and hopefully now my submission on all CRAN test environments be O errors, 0 warnings and 0 notes as per my local environment.
+* win-builder reports 1 NOTE under "checking CRAN incoming feasibility ... NOTE" pointing out, I believe, that this is a New submission that overrides a version that was removed owing to check issues not corrected in time.
 
 
 ### Previous NOTES
@@ -16,19 +15,16 @@ Error: processing vignette 'Points-Inside-Outside-Ellipse.Rmd' failed with diagn
 could not find function "generateSiberGroup"
 --- failed re-building ‘Points-Inside-Outside-Ellipse.Rmd’
 
-* I cant reproduce this warning in either the local or remote test environments, but have added `Suggets: rmarkdown` to DESCRIPTION which from reading various help boards I believe will prevent it.
+* I cant reproduce this warning in either the local or remote test environments, but have added `Suggets: rmarkdown` to DESCRIPTION which from reading various help boards I believe  prevents it.
 
 ## Test environments
 * local OS X 10.14.2 install, R 3.5.2
-* win-builder release
-* win-builder development
+* win-builder release - generates 1 NOTE pointing out this is a New submission that overrides a version that was removed owing to check issues not corrected in time.
+* win-builder development - generates 1 NOTE pointing out this is a New submission that overrides a version that was removed owing to check issues not corrected in time.
 
 
 ## R CMD check results
-* There were no ERRORs or WARNINGs 
-* There were 2 NOTEs. 
-    * The first arises owing to this being a new submission that overwrites the archived version of the same name which was removed owing to it failing checks.
-    * The second results from 3 instances of "no visible binding for global variable 'VAR'" all relating to the function `kapow()` and `siberKapow()`. These all arise from use of `ggplot2` and 'dplyr'. This note can be ignored as the data.frame object passed into `kapow()` and `siberKapow()` will have these variable names. 
+* There were no ERRORs or WARNINGs or NOTEs on my local environment.
 
 ## CRAN Package Check Results for Package SIBER
 * As per note at the start, this package failed the latest round of checks owing to vignette title naming bugs. I have rectified all.


### PR DESCRIPTION
I have removed these two NOTEs. Not by adding global variables, but in both instances by using base syntax and directly naming the variable using dollar sign notation within the data.frame, e.g. `df$group`.